### PR TITLE
Restore test of SD Card present

### DIFF
--- a/Marlin/cardreader.cpp
+++ b/Marlin/cardreader.cpp
@@ -481,7 +481,8 @@ void CardReader::write_command(char *buf) {
 }
 
 void CardReader::checkautostart(bool force) {
-  if (!(force || !autostart_stilltocheck || next_autostart_ms >= millis())) return;
+  if (!force && (!autostart_stilltocheck || next_autostart_ms < millis()))
+    return;
 
   autostart_stilltocheck = false;
 


### PR DESCRIPTION
This fixes issue #43

PR#2572 Changed this because of faulty Boolean Logic

NOT(A OR (NOT B) OR (NOT C)) !=

(NOT A) AND ((NOT B) OR C))


Besides, the compiler should be smart enough to
optimize this without help from the programmer