### PR TITLE
Continue from the line following the M999

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5083,7 +5083,7 @@ inline void gcode_M907() {
 inline void gcode_M999() {
   Running = true;
   lcd_reset_alert_level();
-  gcode_LastN = Stopped_gcode_LastN;
+  // gcode_LastN = Stopped_gcode_LastN;
   FlushSerialRequestResend();
 }
 


### PR DESCRIPTION
If the printer is going to accept the M999,
then it should continue from that line number.


Fixes issue #37