### PR TITLE
After G29 - always end at the same point

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2565,7 +2565,7 @@ inline void gcode_G28() {
       #endif // !DELTA
 
       int probePointCounter = 0;
-      bool zig = true;
+      bool zig = (auto_bed_leveling_grid_points & 1) ? true : false; //always end at [RIGHT_PROBE_BED_POSITION, BACK_PROBE_BED_POSITION]
 
       for (int yCount = 0; yCount < auto_bed_leveling_grid_points; yCount++) {
         double yProbe = front_probe_bed_position + yGridSpacing * yCount;

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2582,13 +2582,7 @@ inline void gcode_G28() {
           xInc = -1;
         }
 
-        #if DISABLED(DELTA)
-          // If do_topography_map is set then don't zig-zag. Just scan in one direction.
-          // This gets the probe points in more readable order.
-          if (!do_topography_map) zig = !zig;
-        #else
-          zig = !zig;
-        #endif
+        zig = !zig;
 
         for (int xCount = xStart; xCount != xStop; xCount += xInc) {
           double xProbe = left_probe_bed_position + xGridSpacing * xCount;

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2561,6 +2561,7 @@ inline void gcode_G28() {
         double eqnAMatrix[abl2 * 3], // "A" matrix of the linear system of equations
                eqnBVector[abl2],     // "B" vector of Z points
                mean = 0.0;
+        int8_t indexIntoAB[auto_bed_leveling_grid_points][auto_bed_leveling_grid_points];
       #endif // !DELTA
 
       int probePointCounter = 0;
@@ -2625,7 +2626,7 @@ inline void gcode_G28() {
             bed_level[xCount][yCount] = measured_z + z_offset;
           #endif
 
-          probePointCounter++;
+          indexIntoAB[xCount][yCount] = probePointCounter++;
 
           idle();
 
@@ -2679,7 +2680,7 @@ inline void gcode_G28() {
 
           for (int yy = auto_bed_leveling_grid_points - 1; yy >= 0; yy--) {
             for (int xx = 0; xx < auto_bed_leveling_grid_points; xx++) {
-              int ind = yy * auto_bed_leveling_grid_points + xx;
+              int ind = indexIntoAB[xx][yy];
               float diff = eqnBVector[ind] - mean;
 
               float x_tmp = eqnAMatrix[ind + 0 * abl2],
@@ -2705,7 +2706,7 @@ inline void gcode_G28() {
 
             for (int yy = auto_bed_leveling_grid_points - 1; yy >= 0; yy--) {
               for (int xx = 0; xx < auto_bed_leveling_grid_points; xx++) {
-                int ind = yy * auto_bed_leveling_grid_points + xx;
+                int ind = indexIntoAB[xx][yy];
                 float x_tmp = eqnAMatrix[ind + 0 * abl2],
                   y_tmp = eqnAMatrix[ind + 1 * abl2],
                   z_tmp = 0;

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2616,12 +2616,13 @@ inline void gcode_G28() {
             eqnAMatrix[probePointCounter + 0 * abl2] = xProbe;
             eqnAMatrix[probePointCounter + 1 * abl2] = yProbe;
             eqnAMatrix[probePointCounter + 2 * abl2] = 1;
+            indexIntoAB[xCount][yCount] = probePointCounter;
           #else
             bed_level[xCount][yCount] = measured_z + z_offset;
           #endif
 
-          indexIntoAB[xCount][yCount] = probePointCounter++;
-
+          probePointCounter++;
+  
           idle();
 
         } //xProbe


### PR DESCRIPTION
Always end at [RIGHT_PROBE_BED_POSITION, BACK_PROBE_BED_POSITION]
Regardless the evenness of auto_bed_leveling_grid_points.

Always zigzag
Use the shortest way between probing-points.

Add array indexIntoAB[xx][yy]
and use it to simplify the output loop when zigzaging.