### PR TITLE
G5 X Y Z Babystepping

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -361,10 +361,23 @@
 // does not respect endstops!
 //#define BABYSTEPPING
 #if ENABLED(BABYSTEPPING)
+     // !!! THIS NULLIFIES (OR ENHANCES) THE ORIGINAL FUNCTIONALITY OF Z-HOME OFFSET !!!
+  //#define BABYSTEP_OFFSET //Babystep the stored Z-Home Offset
+     //If you babystep the Z-axis it will be saved and reapplied immediately after homing.
+     //If you perform an M500 or 'Main > Control > Store memory' from an LCD controller
+     //it will save the actuated babystep offset in the EEPROM.
+     //M206 Z0 or 'Main > Prepare > Set home offsets' at Z=0 will reset the offset back to 0
+     // !!! THIS NULLIFIES (OR ENHANCES) THE ORIGINAL FUNCTIONALITY OF Z-HOME OFFSET !!!
   #define BABYSTEP_XY  //not only z, but also XY in the menu. more clutter, more functions
                        //not implemented for CoreXY and deltabots!
   #define BABYSTEP_INVERT_Z false  //true for inverse movements in Z
   #define BABYSTEP_Z_MULTIPLICATOR 2 //faster z movements
+  #define X_BABY_DEFAULT_MAX_POS X_MAX_POS
+  #define Y_BABY_DEFAULT_MAX_POS Y_MAX_POS
+  #define Z_BABY_DEFAULT_MAX_POS Z_MAX_POS
+  #define X_BABY_DEFAULT_MIN_POS X_MIN_POS
+  #define Y_BABY_DEFAULT_MIN_POS Y_MIN_POS
+  #define Z_BABY_DEFAULT_MIN_POS Z_MIN_POS-10 //be careful, min hardware & software endstops are ignored/extended
 #endif
 
 // @section extruder

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2021,7 +2021,7 @@ static void homeaxis(AxisEnum axis) {
       #endif
     }
 
-    #ifdef BABYSTEPPING
+    #if ENABLED(BABYSTEPPING)
       if(axis == Z_AXIS)
       {
         baby_max_endstop[axis] = Z_BABY_DEFAULT_MAX_POS;
@@ -2213,14 +2213,14 @@ inline void gcode_G4() {
   while (millis() < codenum) idle();
 }
 
-#ifdef BABYSTEPPING
+#if ENABLED(BABYSTEPPING)
   inline void gcode_G5() {
     int8_t axis[3] = { -1, -1, -1 };
-    const uint8_t axis_order[] = { Z_AXIS
+    const uint8_t axis_order[] = {
     #ifdef BABYSTEP_XY
-      , X_AXIS, Y_AXIS // in the order: Z, X, then Y
-    #endif //BABYSTEP_XY
-      };
+      X_AXIS, Y_AXIS,
+    #endif
+    Z_AXIS };
     for (uint8_t i=0; i<(sizeof(axis_order)/sizeof(*axis_order)); i++) {
       boolean endstop = false;
       if (code_seen(axis_codes[axis_order[i]]) && axis[i] == -1) {
@@ -5803,7 +5803,7 @@ void process_next_command() {
         gcode_G4();
         break;
 
-      #ifdef BABYSTEPPING
+      #if ENABLED(BABYSTEPPING)
         case 5:
           gcode_G5();
           break;

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1105,7 +1105,7 @@ static void set_axis_is_at_home(AxisEnum axis) {
     else
   #endif
   {
-    if(axis != Z_AXIS)
+    if (axis != Z_AXIS)
       current_position[axis] = base_home_pos(axis) + home_offset[axis];
     else
       current_position[axis] = base_home_pos(axis)
@@ -2022,19 +2022,16 @@ static void homeaxis(AxisEnum axis) {
     }
 
     #if ENABLED(BABYSTEPPING)
-      if(axis == Z_AXIS)
-      {
+      if (axis == Z_AXIS) {
         baby_max_endstop[axis] = Z_BABY_DEFAULT_MAX_POS;
         baby_min_endstop[axis] = Z_BABY_DEFAULT_MIN_POS;
       }
       #ifdef BABYSTEP_XY
-        else if(axis == X_AXIS)
-        {
+        else if (axis == X_AXIS) {
           baby_max_endstop[axis] = X_BABY_DEFAULT_MAX_POS;
           baby_min_endstop[axis] = X_BABY_DEFAULT_MIN_POS;
         }
-        else if(axis == Y_AXIS)
-        {
+        else if (axis == Y_AXIS) {
           baby_max_endstop[axis] = Y_BABY_DEFAULT_MAX_POS;
           baby_min_endstop[axis] = Y_BABY_DEFAULT_MIN_POS;
         }
@@ -2234,7 +2231,7 @@ inline void gcode_G4() {
       long babysteps = code_value();
       if (babysteps < 0 && (current_position[axis[i]] > baby_min_endstop[axis[i]])) { // negative babysteps on Z can ignore min endstop, be careful!
         SERIAL_PROTOCOLPGM("-= ");
-        if(current_position[axis[i]] + babysteps/axis_steps_per_unit[axis[i]] < baby_min_endstop[axis[i]]) {
+        if (current_position[axis[i]] + babysteps/axis_steps_per_unit[axis[i]] < baby_min_endstop[axis[i]]) {
           endstop = true;
           babysteps = -1 * (current_position[axis[i]] - baby_min_endstop[axis[i]]) * axis_steps_per_unit[axis[i]];
         }
@@ -2245,7 +2242,7 @@ inline void gcode_G4() {
       }
       else if (babysteps > 0 && current_position[axis[i]] < baby_max_endstop[axis[i]]) {
         SERIAL_PROTOCOLPGM("+= ");
-        if(current_position[axis[i]] + babysteps/axis_steps_per_unit[axis[i]] > baby_max_endstop[axis[i]]) {
+        if (current_position[axis[i]] + babysteps/axis_steps_per_unit[axis[i]] > baby_max_endstop[axis[i]]) {
           endstop = true;
           babysteps = (baby_max_endstop[axis[i]] - current_position[axis[i]]) * axis_steps_per_unit[axis[i]];
         }
@@ -2255,7 +2252,7 @@ inline void gcode_G4() {
         babystepsTodo[axis[i]] += babysteps;
       }
       else {
-        if((current_position[axis[i]] == baby_min_endstop[axis[i]] || current_position[axis[i]] == baby_max_endstop[axis[i]]) && babysteps != 0)
+        if ((current_position[axis[i]] == baby_min_endstop[axis[i]] || current_position[axis[i]] == baby_max_endstop[axis[i]]) && babysteps != 0)
           endstop = true;
         SERIAL_PROTOCOL("= 0");
       }
@@ -2269,7 +2266,7 @@ inline void gcode_G4() {
         baby_max_endstop[axis[i]] += baby_min_endstop[axis[i]];
       }
       #ifdef BABYSTEP_OFFSET
-        if(axis[i] == Z_AXIS) // will move to the given (EEPROM saved) babystepped Z height offset when homing but not recognize it
+        if (axis[i] == Z_AXIS) // will move to the given (EEPROM saved) babystepped Z height offset when homing but not recognize it
           home_offset[axis[i]] = Z_BABY_DEFAULT_MIN_POS - baby_min_endstop[axis[i]];
       #endif //BABYSTEP_OFFSET
     }
@@ -2633,9 +2630,9 @@ inline void gcode_G28() {
 
     sync_plan_position();
 
-    if(code_seen(axis_codes[Z_AXIS])) {
-      if(code_value_long() != 0) {
-        current_position[Z_AXIS]=code_value()
+    if (code_seen(axis_codes[Z_AXIS])) {
+      if (code_value_long() != 0) {
+        current_position[Z_AXIS] = code_value()
         #ifndef BABYSTEP_OFFSET // will move to the given (EEPROM saved) babystepped Z height offset when homing but not recognize it
           + home_offset[Z_AXIS]
         #endif
@@ -2682,7 +2679,6 @@ inline void gcode_G28() {
   feedrate_multiplier = saved_feedrate_multiplier;
   refresh_cmd_timeout();
   endstops_hit_on_purpose(); // clear endstop hit flags
-<<<<<<< HEAD
 
   #if ENABLED(DEBUG_LEVELING_FEATURE)
     if (marlin_debug_flags & DEBUG_LEVELING) {
@@ -2690,13 +2686,11 @@ inline void gcode_G28() {
     }
   #endif
 
-=======
   #ifdef BABYSTEP_OFFSET
     baby_max_endstop[Z_AXIS] -= home_offset[Z_AXIS];
     baby_min_endstop[Z_AXIS] -= home_offset[Z_AXIS];
     babystepsTodo[Z_AXIS] += home_offset[Z_AXIS]*axis_steps_per_unit[Z_AXIS];
   #endif
->>>>>>> Initial
 }
 
 #if ENABLED(MESH_BED_LEVELING)
@@ -6341,7 +6335,6 @@ void clamp_to_software_endstops(float target[3]) {
     float negative_z_offset = 0;
     #if ENABLED(AUTO_BED_LEVELING_FEATURE)
       if (zprobe_zoffset < 0) negative_z_offset += zprobe_zoffset;
-<<<<<<< HEAD
       if (home_offset[Z_AXIS] < 0) {
         #if ENABLED(DEBUG_LEVELING_FEATURE)
           if (marlin_debug_flags & DEBUG_LEVELING) {
@@ -6349,13 +6342,10 @@ void clamp_to_software_endstops(float target[3]) {
             SERIAL_EOL;
           }
         #endif
-        negative_z_offset += home_offset[Z_AXIS];
+        #ifndef BABYSTEP_OFFSET
+          if (home_offset[Z_AXIS] < 0) negative_z_offset += home_offset[Z_AXIS];
+        #endif
       }
-=======
-      #ifndef BABYSTEP_OFFSET
-        if (home_offset[Z_AXIS] < 0) negative_z_offset += home_offset[Z_AXIS];
-      #endif
->>>>>>> Initial
     #endif
     NOLESS(target[Z_AXIS], min_pos[Z_AXIS] + negative_z_offset);
   }

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -67,6 +67,8 @@ unsigned char soft_pwm_bed;
   
 #if ENABLED(BABYSTEPPING)
   volatile int babystepsTodo[3] = { 0 };
+  float baby_max_endstop[3] = {X_BABY_DEFAULT_MAX_POS, Y_BABY_DEFAULT_MAX_POS, Z_BABY_DEFAULT_MAX_POS};
+  float baby_min_endstop[3] = {X_BABY_DEFAULT_MIN_POS, Y_BABY_DEFAULT_MIN_POS, Z_BABY_DEFAULT_MIN_POS};
 #endif
 
 #if ENABLED(FILAMENT_SENSOR)

--- a/Marlin/temperature.h
+++ b/Marlin/temperature.h
@@ -79,6 +79,8 @@ extern float current_temperature_bed;
   
 #if ENABLED(BABYSTEPPING)
   extern volatile int babystepsTodo[3];
+  extern float baby_max_endstop[3];
+  extern float baby_min_endstop[3];
 #endif
   
 //high level conversion routines, for use outside of temperature.cpp

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -454,7 +454,7 @@ void lcd_set_home_offsets() {
       baby_max_endstop[axis] -= diff;
       baby_min_endstop[axis] -= diff;
      #ifdef BABYSTEP_OFFSET
-      if(axis == Z_AXIS) home_offset[axis] += diff;
+      if (axis == Z_AXIS) home_offset[axis] += diff;
      #endif //BABYSTEP_OFFSET
       encoderPosition = 0;
       lcdDrawUpdate = 1;

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -450,6 +450,12 @@ void lcd_set_home_offsets() {
   static void _lcd_babystep(int axis, const char *msg) {
     if (encoderPosition != 0) {
       babystepsTodo[axis] += (int)encoderPosition;
+      float diff = int(encoderPosition) / axis_steps_per_unit[axis];
+      baby_max_endstop[axis] -= diff;
+      baby_min_endstop[axis] -= diff;
+     #ifdef BABYSTEP_OFFSET
+      if(axis == Z_AXIS) home_offset[axis] += diff;
+     #endif //BABYSTEP_OFFSET
       encoderPosition = 0;
       lcdDrawUpdate = 1;
     }


### PR DESCRIPTION
G5 X Y Z — The argument is the number of steps to be performed in the positive or negative direction of the given axes. It attempts to prevent endstop crashes to the best of its ability. *** Added the option to babystep the stored `home_offset[Z_AXIS]` if `BABYSTEP_OFFSET` is defined (this can also be performed on an LCD controller, and saved to the EEPROM as with standard home-offsets) ***