### PR TITLE
M19 Z Resume From Z and Layer Counting

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -600,6 +600,25 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define DEFAULT_ZJERK                 0.4     // (mm/sec)
 #define DEFAULT_EJERK                 5.0    // (mm/sec)
 
+//===========================================================================
+//============================== Resume From Z ==============================
+//===========================================================================
+
+//This feature allows you to resume a failed print from given Z height.
+//It parses through the gcode until it passes the given Z threshold height
+//(either from the current location when selecting Menu > Resume SD from Z > file.gcode or just M19; or with M19 Z(some number here)),
+//it also compensates for z-lifts around the given threshold.
+
+//#define RESUME_FEATURE
+
+//===========================================================================
+//============================== Layer Tracking =============================
+//===========================================================================
+
+//This feature keeps track of the current layer, accounting for Z lifts and multiple objects
+//The current layer number can be found in Menu > Tune > Layer whilst printing from an LCD controller (via SD) or by sending M114 (SD or not).
+
+//#define TRACK_LAYER
 
 //=============================================================================
 //============================= Additional Features ===========================

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -259,6 +259,13 @@ extern float home_offset[3]; // axis[n].home_offset
 extern float min_pos[3]; // axis[n].min_pos
 extern float max_pos[3]; // axis[n].max_pos
 extern bool axis_known_position[3]; // axis[n].is_known
+#ifdef RESUME_FEATURE
+  extern float planner_disabled_below_z;
+#endif
+#ifdef TRACK_LAYER
+  extern float last_layer_z;
+  extern unsigned short current_layer; // estimated current layer number
+#endif //TRACK_LAYER
 
 #if ENABLED(DELTA)
   extern float delta[3];

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -3383,8 +3383,7 @@ inline void gcode_M17() {
 
 #ifdef RESUME_FEATURE
   inline void gcode_M19() {
-    if(code_seen('Z'))
-    {
+    if (code_seen('Z')) {
       gcode_get_destination(); // For Z
       prepare_move();
       enqueuecommands_P(PSTR("M114")); // tell the host where it is

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -421,16 +421,14 @@ bool target_direction;
   boolean chdkActive = false;
 #endif
 
-<<<<<<< HEAD
 #if ENABLED(PID_ADD_EXTRUSION_RATE)
   int lpq_len = 20;
 #endif
-=======
-#ifdef RESUME_FEATURE
+
+#if ENABLED(RESUME_FEATURE)
   extern float planner_disabled_below_z;
   extern bool layer_reached;
 #endif //RESUME_FEATURE
->>>>>>> Added Resume From Z and Layer Counting features
 
 //===========================================================================
 //================================ Functions ================================
@@ -948,7 +946,7 @@ void get_command() {
           lcd_setstatus(time, true);
           card.printingHasFinished();
           card.checkautostart(true);
-          #ifdef RESUME_FEATURE
+          #if ENABLED(RESUME_FEATURE)
             planner_disabled_below_z = 0;
           #endif //RESUME_FEATURE
         }
@@ -2250,7 +2248,7 @@ inline void gcode_G4() {
  */
 inline void gcode_G28() {
 
-  #ifdef RESUME_FEATURE
+  #if ENABLED(RESUME_FEATURE)
     if (planner_disabled_below_z) return; // Disable homing if resuming print
   #endif //RESUME_FEATURE
 
@@ -2608,7 +2606,7 @@ inline void gcode_G28() {
     }
   #endif
 
-  #ifdef TRACK_LAYER
+  #if ENABLED(TRACK_LAYER)
     current_layer = 0;
     last_layer_z = 0;
   #endif //TRACK_LAYER
@@ -2650,7 +2648,7 @@ inline void gcode_G28() {
    */
   inline void gcode_G29() {
 
-    #ifdef RESUME_FEATURE
+    #if ENABLED(RESUME_FEATURE)
       if (planner_disabled_below_z) return; // Disable probing if resuming print
     #endif
     static int probe_point = -1;
@@ -2761,7 +2759,7 @@ inline void gcode_G28() {
         mbl.z_values[iy][ix] = z;
 
     } // switch(state)
-    #ifdef TRACK_LAYER
+    #if ENABLED(TRACK_LAYER)
       current_layer = 0;
       last_layer_z = 0;
     #endif //TRACK_LAYER
@@ -2815,7 +2813,7 @@ inline void gcode_G28() {
    */
   inline void gcode_G29() {
 
-    #ifdef RESUME_FEATURE
+    #if ENABLED(RESUME_FEATURE)
       if (planner_disabled_below_z) return; // Disable probing if resuming print
     #endif
 
@@ -3254,7 +3252,7 @@ inline void gcode_G28() {
       }
     #endif
 
-    #ifdef TRACK_LAYER
+    #if ENABLED(TRACK_LAYER)
       current_layer = 0;
       last_layer_z = 0;
     #endif //TRACK_LAYER
@@ -3381,7 +3379,7 @@ inline void gcode_M17() {
   enable_all_steppers();
 }
 
-#ifdef RESUME_FEATURE
+#if ENABLED(RESUME_FEATURE)
   inline void gcode_M19() {
     if (code_seen('Z')) {
       gcode_get_destination(); // For Z
@@ -3438,7 +3436,7 @@ inline void gcode_M17() {
    */
   inline void gcode_M24() {
     card.startFileprint();
-    #ifdef TRACK_LAYER
+    #if ENABLED(TRACK_LAYER)
       current_layer = 0;
       last_layer_z = 0;
     #endif //TRACK_LAYER
@@ -4334,7 +4332,7 @@ inline void gcode_M114() {
   SERIAL_PROTOCOLPGM(" Z:");
   SERIAL_PROTOCOL(st_get_position_mm(Z_AXIS));
 
-  #ifdef TRACK_LAYER
+  #if ENABLED(TRACK_LAYER)
     SERIAL_PROTOCOLPGM("  Layer:");
     SERIAL_PROTOCOL(current_layer);
     SERIAL_PROTOCOLLN("");
@@ -5634,7 +5632,7 @@ inline void gcode_T(uint8_t tmp_extruder) {
     SERIAL_PROTOCOL_F(tmp_extruder,DEC);
     SERIAL_ECHOLN(MSG_INVALID_EXTRUDER);
   }
-  #ifdef RESUME_FEATURE
+  #if ENABLED(RESUME_FEATURE)
     else if (!planner_disabled_below_z || layer_reached);
   #endif
   else {
@@ -5864,7 +5862,7 @@ void process_next_command() {
         gcode_M17();
         break;
 
-      #ifdef RESUME_FEATURE
+      #if ENABLED(RESUME_FEATURE)
         case 19: // M19 - resume Z
           gcode_M19(); break;
       #endif //RESUME_FEATURE

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2250,18 +2250,16 @@ inline void gcode_G4() {
  */
 inline void gcode_G28() {
 
-<<<<<<< HEAD
+  #ifdef RESUME_FEATURE
+    if (planner_disabled_below_z) return; // Disable homing if resuming print
+  #endif //RESUME_FEATURE
+
   #if ENABLED(DEBUG_LEVELING_FEATURE)
     if (marlin_debug_flags & DEBUG_LEVELING) {
       SERIAL_ECHOLNPGM("gcode_G28 >>>");
     }
   #endif
 
-=======
-  #ifdef RESUME_FEATURE
-    if (planner_disabled_below_z) return; // Disable homing if resuming print
-  #endif //RESUME_FEATURE
->>>>>>> Added Resume From Z and Layer Counting features
   // Wait for planner moves to finish!
   st_synchronize();
 
@@ -2816,7 +2814,10 @@ inline void gcode_G28() {
    *
    */
   inline void gcode_G29() {
-<<<<<<< HEAD
+
+    #ifdef RESUME_FEATURE
+      if (planner_disabled_below_z) return; // Disable probing if resuming print
+    #endif
 
     #if ENABLED(DEBUG_LEVELING_FEATURE)
       if (marlin_debug_flags & DEBUG_LEVELING) {
@@ -2824,11 +2825,6 @@ inline void gcode_G28() {
       }
     #endif
 
-=======
-    #ifdef RESUME_FEATURE
-      if (planner_disabled_below_z) return; // Disable probing if resuming print
-    #endif
->>>>>>> Added Resume From Z and Layer Counting features
     // Don't allow auto-leveling without homing first
     if (!axis_known_position[X_AXIS] || !axis_known_position[Y_AXIS]) {
       LCD_MESSAGEPGM(MSG_POSITION_UNKNOWN);
@@ -3251,7 +3247,6 @@ inline void gcode_G28() {
       enqueuecommands_P(PSTR(Z_PROBE_END_SCRIPT));
       st_synchronize();
     #endif
-<<<<<<< HEAD
 
     #if ENABLED(DEBUG_LEVELING_FEATURE)
       if (marlin_debug_flags & DEBUG_LEVELING) {
@@ -3259,12 +3254,10 @@ inline void gcode_G28() {
       }
     #endif
 
-=======
     #ifdef TRACK_LAYER
       current_layer = 0;
       last_layer_z = 0;
     #endif //TRACK_LAYER
->>>>>>> Added Resume From Z and Layer Counting features
   }
 
   #if DISABLED(Z_PROBE_SLED)

--- a/Marlin/language_en.h
+++ b/Marlin/language_en.h
@@ -168,6 +168,21 @@
 #ifndef MSG_FLOW
 #define MSG_FLOW                            "Flow"
 #endif
+#ifndef MSG_LAYER
+#define MSG_LAYER                           "Layer"
+#endif
+#ifndef MSG_F0
+#define MSG_F0                              " 0"
+#endif
+#ifndef MSG_F1
+#define MSG_F1                              " 1"
+#endif
+#ifndef MSG_F2
+#define MSG_F2                              " 2"
+#endif
+#ifndef MSG_F3
+#define MSG_F3                              " 3"
+#endif
 #ifndef MSG_CONTROL
 #define MSG_CONTROL                         "Control"
 #endif
@@ -320,6 +335,9 @@
 #endif
 #ifndef MSG_PAUSE_PRINT
 #define MSG_PAUSE_PRINT                     "Pause print"
+#endif
+#ifndef MSG_CARD_RESUME_MENU
+#define MSG_CARD_RESUME_MENU                "Resume SD from Z"
 #endif
 #ifndef MSG_RESUME_PRINT
 #define MSG_RESUME_PRINT                    "Resume print"

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -489,28 +489,24 @@ void check_axes_activity() {
   void floor_z(const float &z)
   {
     // filter out moves below a given floor height and attempt to ignore any hops/travels
-    if(planner_disabled_below_z && !layer_reached)
-    {
-      if(z < planner_disabled_below_z)
-      {
-        if(z > last_z && !gone_up) // up once
+    if (planner_disabled_below_z && !layer_reached) {
+      if (z < planner_disabled_below_z) {
+        if (z > last_z && !gone_up) // up once
           gone_up = true;
-        else if(z < last_z) // back down
-        {
+        else if (z < last_z) { // back down
           #ifdef TRACK_LAYER
-            if(z > last_layer_z)
+            if (z > last_layer_z)
               current_layer++;
-            else if(z < last_layer_z && z != 0)
+            else if (z < last_layer_z && z != 0)
               current_layer = 1; // if it goes lower than what we would think was the previous layer then we might as well assume it's printing another object
-            else if(z == 0)
+            else if (z == 0)
               current_layer = 0;
             last_layer_z = z;
           #endif //TRACK_LAYER
           hops = true;
           gone_up = false;
         }
-        else if(z > last_z && gone_up) // up twice
-        {
+        else if (z > last_z && gone_up) { // up twice
           #ifdef TRACK_LAYER
             current_layer++; // be careful with prints like the spiral vase
           #endif //TRACK_LAYER
@@ -520,19 +516,17 @@ void check_axes_activity() {
         last_z = z;
         return;
       }
-      else if(hops && !z_reached)
-      {
+      else if (hops && !z_reached) {
         z_reached = true;
         last_z = z;
         return;
       }
-      else if(hops && z == last_z)
+      else if (hops && z == last_z)
         return;
       else
         layer_reached = true;
     }
-    else if(planner_disabled_below_z && z < planner_disabled_below_z)
-    {
+    else if (planner_disabled_below_z && z < planner_disabled_below_z) {
       z_reached = false;
       layer_reached = false;
       return;
@@ -543,20 +537,19 @@ void check_axes_activity() {
 #ifdef TRACK_LAYER
   void layer_count(const float &z)
   {
-    if(z > last_z && !gone_up) // up once
+    if (z > last_z && !gone_up) // up once
       gone_up = true;
-    else if(z < last_z) // back down
-    {
-      if(z > last_layer_z)
+    else if (z < last_z) { // back down
+      if (z > last_layer_z)
         current_layer++;
-      else if(z < last_layer_z && z != 0)
+      else if (z < last_layer_z && z != 0)
         current_layer = 1; // if it goes lower than what we would think was the previous layer then we might as well assume it's printing another object
-      else if(z == 0)
+      else if (z == 0)
         current_layer = 0;
       last_layer_z = z;
       gone_up = false;
     }
-    else if(z > last_z && gone_up) // up twice
+    else if (z > last_z && gone_up) // up twice
       current_layer++; // be careful with prints like the spiral vase
 
     last_z = z;

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -76,6 +76,22 @@ float max_z_jerk;
 float max_e_jerk;
 float mintravelfeedrate;
 unsigned long axis_steps_per_sqr_second[NUM_AXIS];
+#ifdef RESUME_FEATURE
+  float planner_disabled_below_z = 0;
+  float last_z = 0;
+  bool z_reached = false;
+  bool layer_reached = false;
+  bool hops = false;
+  bool gone_up = false;
+#endif //RESUME_FEATURE
+#ifdef TRACK_LAYER
+  unsigned short current_layer = 0;
+  float last_layer_z = 0;
+  #ifndef RESUME_FEATURE
+    bool gone_up = false;
+    float last_z = 0;
+  #endif //RESUME_FEATURE
+#endif //TRACK_LAYER
 
 #if ENABLED(AUTO_BED_LEVELING_FEATURE)
   // Transform required to compensate for bed level
@@ -469,9 +485,86 @@ void check_axes_activity() {
   #endif
 }
 
+#ifdef RESUME_FEATURE
+  void floor_z(const float &z)
+  {
+    // filter out moves below a given floor height and attempt to ignore any hops/travels
+    if(planner_disabled_below_z && !layer_reached)
+    {
+      if(z < planner_disabled_below_z)
+      {
+        if(z > last_z && !gone_up) // up once
+          gone_up = true;
+        else if(z < last_z) // back down
+        {
+          #ifdef TRACK_LAYER
+            if(z > last_layer_z)
+              current_layer++;
+            else if(z < last_layer_z && z != 0)
+              current_layer = 1; // if it goes lower than what we would think was the previous layer then we might as well assume it's printing another object
+            else if(z == 0)
+              current_layer = 0;
+            last_layer_z = z;
+          #endif //TRACK_LAYER
+          hops = true;
+          gone_up = false;
+        }
+        else if(z > last_z && gone_up) // up twice
+        {
+          #ifdef TRACK_LAYER
+            current_layer++; // be careful with prints like the spiral vase
+          #endif //TRACK_LAYER
+          hops = false;
+        }
+        z_reached = false;
+        last_z = z;
+        return;
+      }
+      else if(hops && !z_reached)
+      {
+        z_reached = true;
+        last_z = z;
+        return;
+      }
+      else if(hops && z == last_z)
+        return;
+      else
+        layer_reached = true;
+    }
+    else if(planner_disabled_below_z && z < planner_disabled_below_z)
+    {
+      z_reached = false;
+      layer_reached = false;
+      return;
+    }
+  }
+#endif //RESUME_FEATURE
+
+#ifdef TRACK_LAYER
+  void layer_count(const float &z)
+  {
+    if(z > last_z && !gone_up) // up once
+      gone_up = true;
+    else if(z < last_z) // back down
+    {
+      if(z > last_layer_z)
+        current_layer++;
+      else if(z < last_layer_z && z != 0)
+        current_layer = 1; // if it goes lower than what we would think was the previous layer then we might as well assume it's printing another object
+      else if(z == 0)
+        current_layer = 0;
+      last_layer_z = z;
+      gone_up = false;
+    }
+    else if(z > last_z && gone_up) // up twice
+      current_layer++; // be careful with prints like the spiral vase
+
+    last_z = z;
+  }
+#endif //TRACK_LAYER
 
 float junction_deviation = 0.1;
-// Add a new linear movement to the buffer. steps[X_AXIS], _y and _z is the absolute position in
+// Add a new linear movement to the buffer. steps[X_AXIS], _y and _z is the absolute position in 
 // mm. Microseconds specify how many microseconds the move should take to perform. To aid acceleration
 // calculation the caller must also provide the physical length of the line in millimeters.
 #if ENABLED(AUTO_BED_LEVELING_FEATURE) || ENABLED(MESH_BED_LEVELING)
@@ -480,6 +573,14 @@ float junction_deviation = 0.1;
   void plan_buffer_line(const float &x, const float &y, const float &z, const float &e, float feed_rate, const uint8_t extruder)
 #endif  // AUTO_BED_LEVELING_FEATURE
 {
+  #ifdef RESUME_FEATURE
+    floor_z(z);
+  #endif
+
+  #ifdef TRACK_LAYER
+    layer_count(z);
+  #endif //TRACK_LAYER
+
   // Calculate the buffer head after we push this byte
   int next_buffer_head = next_block_index(block_buffer_head);
 

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -64,7 +64,7 @@ static void lcd_status_screen();
     static void lcd_control_retract_menu();
   #endif
 
-  #ifdef RESUME_FEATURE
+  #if ENABLED(RESUME_FEATURE)
     static void lcd_sdcard_resume_menu();
     static void lcd_sdcard_print_menu();
     extern float planner_disabled_below_z;
@@ -390,7 +390,6 @@ static void lcd_return_to_status() { lcd_goto_menu(lcd_status_screen); }
 
   static void lcd_sdcard_pause() { card.pauseSDPrint(); }
 
-<<<<<<< HEAD
   static void lcd_sdcard_resume() { card.startFileprint(); }
 
   static void lcd_sdcard_stop() {
@@ -400,22 +399,12 @@ static void lcd_return_to_status() { lcd_goto_menu(lcd_status_screen); }
     autotempShutdown();
     cancel_heatup = true;
     lcd_setstatus(MSG_PRINT_ABORTED, true);
+    #if ENABLED(RESUME_FEATURE)
+      planner_disabled_below_z = 0;
+    #endif //RESUME_FEATURE
   }
 
 #endif //SDSUPPORT
-=======
-static void lcd_sdcard_stop() {
-  quickStop();
-  card.sdprinting = false;
-  card.closefile();
-  autotempShutdown();
-  cancel_heatup = true;
-  lcd_setstatus(MSG_PRINT_ABORTED, true);
-  #ifdef RESUME_FEATURE
-    planner_disabled_below_z = 0;
-  #endif //RESUME_FEATURE
-}
->>>>>>> Added Resume From Z and Layer Counting features
 
 /**
  *
@@ -447,7 +436,7 @@ static void lcd_main_menu() {
         MENU_ITEM(function, MSG_STOP_PRINT, lcd_sdcard_stop);
       }
       else {
-        #ifdef RESUME_FEATURE
+        #if ENABLED(RESUME_FEATURE)
           MENU_ITEM(submenu, MSG_CARD_MENU, lcd_sdcard_print_menu);
           if (current_position[Z_AXIS] > 0)
             MENU_ITEM(submenu, MSG_CARD_RESUME_MENU, lcd_sdcard_resume_menu);
@@ -569,7 +558,6 @@ static void lcd_tune_menu() {
   //
   MENU_ITEM_EDIT(int3, MSG_FLOW, &extruder_multiplier[active_extruder], 10, 999);
 
-<<<<<<< HEAD
   //
   // Flow:
   // Flow 1:
@@ -590,18 +578,16 @@ static void lcd_tune_menu() {
     #endif //EXTRUDERS > 2
   #endif //EXTRUDERS > 1
 
+  #if ENABLED(TRACK_LAYER)
+    int layer = current_layer;
+    MENU_ITEM_EDIT(int3, MSG_LAYER, &layer, layer, layer);
+  #endif //TRACK_LAYER
+
   //
   // Babystep X:
   // Babystep Y:
   // Babystep Z:
   //
-=======
-  #ifdef TRACK_LAYER
-    int layer = current_layer;
-    MENU_ITEM_EDIT(int3, MSG_LAYER, &layer, layer, layer);
-  #endif //TRACK_LAYER
-
->>>>>>> Added Resume From Z and Layer Counting features
   #if ENABLED(BABYSTEPPING)
     #if ENABLED(BABYSTEP_XY)
       MENU_ITEM(submenu, MSG_BABYSTEP_X, lcd_babystep_x);
@@ -1315,22 +1301,20 @@ static void lcd_control_volumetric_menu() {
     }
   #endif
 
-<<<<<<< HEAD
   static void lcd_sd_updir() {
     card.updir();
     currentMenuViewOffset = 0;
-=======
-#ifdef RESUME_FEATURE
+  }
+
+#if ENABLED(RESUME_FEATURE)
   // Print from SD
-  void lcd_sdcard_print_menu()
-  {
+  void lcd_sdcard_print_menu() {
     planner_disabled_below_z = 0;
     lcd_sdcard_menu();
   }
 
   // Print from SD but set flag to ignore movements below a certain Z
-  void lcd_sdcard_resume_menu()
-  {
+  void lcd_sdcard_resume_menu() {
     planner_disabled_below_z = current_position[Z_AXIS];
     last_z = 0;
     z_reached = false;
@@ -1340,27 +1324,6 @@ static void lcd_control_volumetric_menu() {
     lcd_sdcard_menu();
   }
 #endif //RESUME_FEATURE
-
-/**
- *
- * "Print from SD" submenu
- *
- */
-void lcd_sdcard_menu() {
-  if (lcdDrawUpdate == 0 && LCD_CLICKED == 0) return;	// nothing to do (so don't thrash the SD card)
-  uint16_t fileCnt = card.getnrfilenames();
-  START_MENU();
-  MENU_ITEM(back, MSG_MAIN, lcd_main_menu);
-  card.getWorkDirName();
-  if (card.filename[0] == '/') {
-    #if !PIN_EXISTS(SD_DETECT)
-      MENU_ITEM(function, LCD_STR_REFRESH MSG_REFRESH, lcd_sd_refresh);
-    #endif
-  }
-  else {
-    MENU_ITEM(function, LCD_STR_FOLDER "..", lcd_sd_updir);
->>>>>>> Added Resume From Z and Layer Counting features
-  }
 
   /**
    *

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -449,7 +449,7 @@ static void lcd_main_menu() {
       else {
         #ifdef RESUME_FEATURE
           MENU_ITEM(submenu, MSG_CARD_MENU, lcd_sdcard_print_menu);
-          if(current_position[Z_AXIS] > 0)
+          if (current_position[Z_AXIS] > 0)
             MENU_ITEM(submenu, MSG_CARD_RESUME_MENU, lcd_sdcard_resume_menu);
         #endif //RESUME_FEATURE
         #if !PIN_EXISTS(SD_DETECT)


### PR DESCRIPTION
- M19 Z and Resume From Z in LCD main menu — resumes a failed print from given Z height (modified [Vince's Solidoodle code](http://www.soliforum.com/topic/5971/firmware-mods-to-rescue-and-resume-failed-prints/) and included an algorithm to compensate for Z-lifts)
- Accounts for multiple extruders
- Added layer counting — found using M114 or Menu > Tune > Layer from an LCD

These features must be included together in this PR because merging them would require additional editing (potential conflicts).