### PR TITLE
Fix home/quickhome for corexy/xz

### DIFF
--- a/Marlin/macros.h
+++ b/Marlin/macros.h
@@ -1,6 +1,8 @@
 #ifndef MACROS_H
 #define MACROS_H
 
+#include <math.h>
+
 // Macros for bit masks
 #define BIT(b) (1<<(b))
 #define TEST(n,b) (((n)&BIT(b))!=0)
@@ -23,5 +25,10 @@
 #define DISABLED(b) (!_CAT(SWITCH_ENABLED_, b))
 
 #define COUNT(a) (sizeof(a)/sizeof(*a))
+
+// float helpers
+#define EPSILON ((float)0.0000001)
+inline bool nearly_zero(float x) { return fabs(x) < EPSILON; }
+inline bool nearly_equal(float x, float y) { return nearly_zero(x - y); }
 
 #endif //__MACROS_H

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -544,11 +544,19 @@ float junction_deviation = 0.1;
     block->steps[A_AXIS] = labs(dx + dy);
     block->steps[B_AXIS] = labs(dx - dy);
     block->steps[Z_AXIS] = labs(dz);
+    block->is_axis_moving[X_AXIS] = !nearly_zero(dx);
+    block->is_axis_moving[Y_AXIS] = !nearly_zero(dy);
+    block->is_axis_moving[Z_AXIS] = !nearly_zero(dz);
+    block->is_axis_moving[E_AXIS] = !nearly_zero(de);    
   #elif ENABLED(COREXZ)
     // corexz planning
     block->steps[A_AXIS] = labs(dx + dz);
     block->steps[Y_AXIS] = labs(dy);
     block->steps[C_AXIS] = labs(dx - dz);
+    block->is_axis_moving[X_AXIS] = !nearly_zero(dx);
+    block->is_axis_moving[Y_AXIS] = !nearly_zero(dy);
+    block->is_axis_moving[Z_AXIS] = !nearly_zero(dz);
+    block->is_axis_moving[E_AXIS] = !nearly_zero(de);
   #else
     // default non-h-bot planning
     block->steps[X_AXIS] = labs(dx);
@@ -1039,3 +1047,4 @@ void reset_acceleration_rates() {
   for (int i = 0; i < NUM_AXIS; i++)
     axis_steps_per_sqr_second[i] = max_acceleration_units_per_sq_second[i] * axis_steps_per_unit[i];
 }
+

--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -43,7 +43,9 @@ typedef struct {
     volatile long final_advance;
     float advance;
   #endif
-
+  #if (ENABLED(COREXY) || ENABLED(COREXZ))
+    bool is_axis_moving[NUM_AXIS];			// needed for the homing of corexn
+  #endif
   // Fields used by the motion planner to manage acceleration
   // float speed_x, speed_y, speed_z, speed_e;          // Nominal mm/sec for each axis
   float nominal_speed;                               // The nominal speed for this block in mm/sec 
@@ -168,3 +170,4 @@ FORCE_INLINE block_t *plan_get_current_block() {
 void reset_acceleration_rates();
 
 #endif // PLANNER_H
+

--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -309,13 +309,18 @@ inline void update_endstops() {
   // TEST_ENDSTOP: test the old and the current status of an endstop
   #define TEST_ENDSTOP(ENDSTOP) (TEST(current_endstop_bits, ENDSTOP) && TEST(old_endstop_bits, ENDSTOP))
 
-  #define UPDATE_ENDSTOP(AXIS,MINMAX) \
+  #define _UPDATE_ENDSTOP(AXIS,MINMAX,FIELD) \
     SET_ENDSTOP_BIT(AXIS, MINMAX); \
-    if (TEST_ENDSTOP(_ENDSTOP(AXIS, MINMAX))  && (current_block->steps[_AXIS(AXIS)] > 0)) { \
+    if (TEST_ENDSTOP(_ENDSTOP(AXIS, MINMAX)) && current_block->FIELD[_AXIS(AXIS)] > 0) { \
       endstops_trigsteps[_AXIS(AXIS)] = count_position[_AXIS(AXIS)]; \
       _ENDSTOP_HIT(AXIS); \
       step_events_completed = current_block->step_event_count; \
     }
+  #if ENABLED(COREXY) || ENABLED(COREXZ)
+    #define UPDATE_ENDSTOP(AXIS,MINMAX) _UPDATE_ENDSTOP(AXIS,MINMAX,is_axis_moving)
+  #else
+    #define UPDATE_ENDSTOP(AXIS,MINMAX) _UPDATE_ENDSTOP(AXIS,MINMAX,steps)
+  #endif
   
   #if ENABLED(COREXY)
     // Head direction in -X axis for CoreXY bots.
@@ -1311,3 +1316,4 @@ void microstep_readings() {
   void Lock_z_motor(bool state) { locked_z_motor = state; }
   void Lock_z2_motor(bool state) { locked_z2_motor = state; }
 #endif
+


### PR DESCRIPTION
Coming from #57 , https://github.com/MarlinFirmware/Marlin/pull/2378,  https://github.com/MarlinFirmware/Marlin/pull/2255.

Resume: There is a bug in the coreXY/XZ homing implementation, that is only exposed when enabling QUICK_HOME. It fetches raw steps (a/b) from the sttepers instead of axis movement (x/y). 

This is another approach to the issue,same essence but this time using just bools on ISR time.

@thinkyhead I think you wanted included the float helpers and the rawX/Y/Z movement. I included the helper functions but removed the floats with raw dx/dy/dz from the block as its now done with a bool I don't have any inmediate use for them.

While doing the fix was thinking if it might have sense to have the is_axis_moving[] array enabled in all configurations, but then again doesn't have an immediate use beyond fixing the core issue.