### PR TITLE
Drop www. from marlinfirmware.org

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -71,7 +71,7 @@
  *  - http://objects.reprap.org/wiki/Mendel_User_Manual:_RepRapGCodes
  *
  * Help us document these G-codes online:
- *  - http://www.marlinfirmware.org/index.php/G-Code
+ *  - http://marlinfirmware.org/index.php/G-Code
  *  - http://reprap.org/wiki/G-code
  *
  * -----------------

--- a/Marlin/ultralcd_implementation_hitachi_HD44780.h
+++ b/Marlin/ultralcd_implementation_hitachi_HD44780.h
@@ -486,7 +486,7 @@ unsigned lcd_print(char c) { return charset_mapper(c); }
     lcd.setCursor(TEXT_SCREEN_LOGO_SHIFT, 1);                    lcd_printPGM(PSTR("|Marlin|"));
     lcd.setCursor(TEXT_SCREEN_LOGO_SHIFT, 2); lcd.print('\x02'); lcd_printPGM(PSTR( "------" ));  lcd.print('\x03');
 
-    lcd_scroll(0, 3, PSTR("www.marlinfirmware.org"), LCD_WIDTH, 3000);
+    lcd_scroll(0, 3, PSTR("marlinfirmware.org"), LCD_WIDTH, 3000);
 
     #ifdef STRING_SPLASH_LINE1
       lcd_erase_line(3);


### PR DESCRIPTION
Noted in #168, removing the "www." prefix prevents display scrolling and isn't needed anyway.