### PR TITLE
Fixed continuous homing when pressing home button on LCD controller.

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -6978,7 +6978,7 @@ void manage_inactivity(bool ignore_stepper_queue/*=false*/) {
     // Check to see if we have to home, use poor man's debouncer
     // ---------------------------------------------------------
     static int homeDebounceCount = 0;   // poor man's debouncing count
-    const int HOME_DEBOUNCE_DELAY = 750;
+    const int HOME_DEBOUNCE_DELAY = 2500;
     if (!READ(HOME_PIN)) {
       if (!homeDebounceCount) {
         enqueuecommands_P(PSTR("G28"));


### PR DESCRIPTION
Fix: increased debounce delay on home button for LCD controllers. The default debounce delay was too short and was causing several homing for each button press.