### PR TITLE
Give lcd_sd_status an UNKNOWN state

### DIFF
--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -227,7 +227,7 @@ static void lcd_status_screen();
   uint8_t lastEncoderBits;
   uint32_t encoderPosition;
   #if PIN_EXISTS(SD_DETECT)
-    bool lcd_sd_status;
+    uint8_t lcd_sd_status;
   #endif
 
 #endif // ULTIPANEL
@@ -1534,7 +1534,7 @@ void lcd_init() {
   #if ENABLED(SDSUPPORT) && PIN_EXISTS(SD_DETECT)
     pinMode(SD_DETECT_PIN, INPUT);
     WRITE(SD_DETECT_PIN, HIGH);
-    lcd_sd_status = false;
+    lcd_sd_status = 2; // UNKNOWN
   #endif
 
   #if ENABLED(LCD_HAS_SLOW_BUTTONS)
@@ -1595,21 +1595,22 @@ void lcd_update() {
     bool sd_status = IS_SD_INSERTED;
     if (sd_status != lcd_sd_status && lcd_detected()) {
       lcdDrawUpdate = 2;
-      lcd_sd_status = sd_status;
       lcd_implementation_init( // to maybe revive the LCD if static electricity killed it.
         #if ENABLED(LCD_PROGRESS_BAR)
           currentMenu == lcd_status_screen
         #endif
       );
 
-      if (lcd_sd_status) {
+      if (sd_status) {
         card.initsd();
-        LCD_MESSAGEPGM(MSG_SD_INSERTED);
+        if (lcd_sd_status != 2) LCD_MESSAGEPGM(MSG_SD_INSERTED);
       }
       else {
         card.release();
-        LCD_MESSAGEPGM(MSG_SD_REMOVED);
+        if (lcd_sd_status != 2) LCD_MESSAGEPGM(MSG_SD_REMOVED);
       }
+
+      lcd_sd_status = sd_status;
     }
 
   #endif //SDSUPPORT && SD_DETECT_PIN


### PR DESCRIPTION
Fix a regression introduced with #165.

As noted in #135, if you have an SD card already in the slot during initialization some controllers will fail to detect it. However, the original fix produced a side-effect that "Card inserted" would appear on the LCD on reset or boot. This PR adds an UNKNOWN state to `lcd_sd_status` so that the message can be suppressed if the card is detected during initialization.