### PR TITLE
Add support for G20/G21 and inch mode

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -198,6 +198,8 @@ enum AxisEnum {X_AXIS=0, A_AXIS=0, Y_AXIS=1, B_AXIS=1, Z_AXIS=2, C_AXIS=2, E_AXI
 
 enum EndstopEnum {X_MIN=0, Y_MIN=1, Z_MIN=2, Z_MIN_PROBE=3, X_MAX=4, Y_MAX=5, Z_MAX=6, Z2_MIN=7, Z2_MAX=8};
 
+typedef enum { LINEARUNIT_MM = 0, LINEARUNIT_INCH = 1 } LinearUnit;
+
 void enable_all_steppers();
 void disable_all_steppers();
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -87,6 +87,8 @@
  * G4  - Dwell S<seconds> or P<milliseconds>
  * G10 - retract filament according to settings of M207
  * G11 - retract recover filament according to settings of M208
+ * G20 - Set input units to inches
+ * G21 - Set input units to millimeters
  * G28 - Home one or more axes
  * G29 - Detailed Z probe, probes the bed at 3 or more points.  Will fail if you haven't homed yet.
  * G30 - Single Z probe, probes bed at current XY location.

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -253,7 +253,7 @@ static int cmd_queue_index_w = 0;
 static int commands_in_queue = 0;
 static char command_queue[BUFSIZE][MAX_CMD_SIZE];
 
-bool in_inchmode = false;
+LinearUnit input_linear_unit = LINEARUNIT_MM;
 const float homing_feedrate[] = HOMING_FEEDRATE;
 bool axis_relative_modes[] = AXIS_RELATIVE_MODES;
 int feedrate_multiplier = 100; //100->1 200->2
@@ -994,7 +994,13 @@ long code_value_long() { return strtol(seen_pointer + 1, NULL, 10); }
 int16_t code_value_short() { return (int16_t)strtol(seen_pointer + 1, NULL, 10); }
 
 inline float linear_unit_modifier() {
-  return (in_inchmode ? 25.4 : 1.0);
+  switch (input_linear_unit) {
+    case LINEARUNIT_INCH:
+      return 25.4;
+    case LINEARUNIT_MM:
+    default:
+      return 1.0;
+  }
 }
 
 inline float volumetric_unit_modifier() {
@@ -2253,14 +2259,14 @@ inline void gcode_G4() {
  * G20: Set input mode to inches
  */
 inline void gcode_G20() {
-  in_inchmode = true;
+  input_linear_unit = LINEARUNIT_INCH;
 }
 
 /**
  * G21: Set input mode to millimeters
  */
 inline void gcode_G21() {
-  in_inchmode = false;
+  input_linear_unit = LINEARUNIT_MM;
 }
 
 /**


### PR DESCRIPTION
Inch mode is common in generated G-code for CNC machines. This approach to integrating an inch mode avoids having to update any internal algorithms or constants by converting values as they are read in from the G-code file.