### PR TITLE
Fix for LCD Contrast issues

### DIFF
--- a/Marlin/Conditionals.h
+++ b/Marlin/Conditionals.h
@@ -32,6 +32,8 @@
       #define DEFAULT_LCD_CONTRAST 40
     #elif ENABLED(ELB_FULL_GRAPHIC_CONTROLLER)
       #define DEFAULT_LCD_CONTRAST 110
+      #define LCD_CONTRAST_MIN 90
+      #define LCD_CONTRAST_MAX 130
       #define U8GLIB_LM6059_AF
     #endif
 
@@ -194,17 +196,27 @@
   /**
   * Default LCD contrast for dogm-like LCD displays
   */
-  #if ENABLED(DOGLCD) && DISABLED(DEFAULT_LCD_CONTRAST)
+  #if ENABLED(DOGLCD) && !defined(DEFAULT_LCD_CONTRAST)
     #define DEFAULT_LCD_CONTRAST 32
   #endif
 
   #if ENABLED(DOGLCD)
     #define HAS_LCD_CONTRAST
+    
     #if ENABLED(U8GLIB_ST7920)
       #undef HAS_LCD_CONTRAST
     #endif
     #if ENABLED(U8GLIB_SSD1306)
       #undef HAS_LCD_CONTRAST
+    #endif
+    
+    #if ENABLED(HAS_LCD_CONTRAST)
+      #if !defined(LCD_CONTRAST_MIN)
+        #define LCD_CONTRAST_MIN 0
+      #endif
+      #if !defined(LCD_CONTRAST_MAX)
+        #define LCD_CONTRAST_MAX 63
+      #endif
     #endif
   #endif
 

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -295,7 +295,7 @@
   // as SD_DETECT_PIN in your board's pins definitions.
   // This setting should be disabled unless you are using a push button, pulling the pin to ground.
   // Note: This is always disabled for ULTIPANEL (except ELB_FULL_GRAPHIC_CONTROLLER).
-  #define SD_DETECT_INVERTED
+  //#define SD_DETECT_INVERTED
 
   #define SD_FINISHED_STEPPERRELEASE true  //if sd support and the file is finished: disable steppers?
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -4305,7 +4305,7 @@ inline void gcode_M240() {
  * M250: Read and optionally set the LCD contrast
  */
 inline void gcode_M250() {
-  if (code_seen('C')) lcd_setcontrast(code_value_short() & 0x3F);
+  if (code_seen('C')) lcd_setcontrast(code_value_short());
   SERIAL_PROTOCOLPGM("lcd contrast value: ");
   SERIAL_PROTOCOL(lcd_contrast);
   SERIAL_EOL;

--- a/Marlin/dogm_lcd_implementation.h
+++ b/Marlin/dogm_lcd_implementation.h
@@ -193,7 +193,7 @@ char lcd_printPGM(const char* str) {
 
 /* Warning: This function is called from interrupt context */
 static void lcd_implementation_init() {
-#if ENABLED(LCD_PIN_BL) // Enable LCD backlight
+#if defined(LCD_PIN_BL) // Enable LCD backlight
   pinMode(LCD_PIN_BL, OUTPUT);
   digitalWrite(LCD_PIN_BL, HIGH);
 #endif

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1163,13 +1163,9 @@ static void lcd_control_volumetric_menu() {
 #if ENABLED(HAS_LCD_CONTRAST)
 static void lcd_set_contrast() {
   if (encoderPosition != 0) {
-#if ENABLED(U8GLIB_LM6059_AF)
     lcd_contrast += encoderPosition;
-    lcd_contrast &= 0xFF;
-#else
-    lcd_contrast -= encoderPosition;
-    lcd_contrast &= 0x3F;
-#endif
+    lcd_contrast = constrain(lcd_contrast, LCD_CONTRAST_MIN, LCD_CONTRAST_MAX);
+
     encoderPosition = 0;
     lcdDrawUpdate = 1;
     u8g.setContrast(lcd_contrast);
@@ -1688,7 +1684,7 @@ void lcd_reset_alert_level() { lcd_status_message_level = 0; }
 
 #if ENABLED(HAS_LCD_CONTRAST)
 void lcd_setcontrast(uint8_t value) {
-  lcd_contrast = value & 0x3F;
+  lcd_contrast = value;
   u8g.setContrast(lcd_contrast);
 }
 #endif


### PR DESCRIPTION
Removes the 0-63 range limit for contrast values.  Replaces the ENABLED
macro that was being used on defined values that were not 0 or 1.  This
is a temporary fix until the ENABLED/DISABLED macros can handle this
type.