### PR TITLE
Fix LCD_PIN_BL and LCD_PIN_RESET in DogM

### DIFF
--- a/dogm_lcd_implementation.h
+++ b/dogm_lcd_implementation.h
@@ -197,18 +197,20 @@ char lcd_printPGM(const char* str) {
 /* Warning: This function is called from interrupt context */
 static void lcd_implementation_init() {
 
-  #if ENABLED(LCD_PIN_BL) // Enable LCD backlight
+  #if defined(LCD_PIN_BL) && LCD_PIN_BL > -1 // Enable LCD backlight
     pinMode(LCD_PIN_BL, OUTPUT);
     digitalWrite(LCD_PIN_BL, HIGH);
   #endif
 
-  #if ENABLED(LCD_PIN_RESET)
+  #if defined(LCD_PIN_RESET) && LCD_PIN_RESET > -1
     pinMode(LCD_PIN_RESET, OUTPUT);
     digitalWrite(LCD_PIN_RESET, HIGH);
   #endif
+
   #if DISABLED(MINIPANEL) // setContrast not working for Mini Panel
     u8g.setContrast(lcd_contrast);
   #endif
+
   // FIXME: remove this workaround
   // Uncomment this if you have the first generation (V1.10) of STBs board
   // pinMode(17, OUTPUT); // Enable LCD backlight


### PR DESCRIPTION
These are pins, so should be tested with `defined(MY_PIN)` instead. (For pins ending in `_PIN` we can use `PIN_EXISTS(MY)` instead.)