### PR TITLE
Simplify watchdog slightly

### DIFF
--- a/Marlin_main.cpp
+++ b/Marlin_main.cpp
@@ -45,12 +45,15 @@
 #include "stepper.h"
 #include "temperature.h"
 #include "cardreader.h"
-#include "watchdog.h"
 #include "configuration_store.h"
 #include "language.h"
 #include "pins_arduino.h"
 #include "math.h"
 #include "buzzer.h"
+
+#if ENABLED(USE_WATCHDOG)
+  #include "watchdog.h"
+#endif
 
 #if ENABLED(BLINKM)
   #include "blinkm.h"
@@ -681,7 +684,11 @@ void setup() {
 
   tp_init();    // Initialize temperature loop
   plan_init();  // Initialize planner;
-  watchdog_init();
+
+  #if ENABLED(USE_WATCHDOG)
+    watchdog_init();
+  #endif
+
   st_init();    // Initialize stepper, this enables interrupts!
   setup_photpin();
   servo_init();

--- a/temperature.cpp
+++ b/temperature.cpp
@@ -21,10 +21,12 @@
 #include "Marlin.h"
 #include "ultralcd.h"
 #include "temperature.h"
-#include "watchdog.h"
 #include "language.h"
-
 #include "Sd2PinMap.h"
+
+#if ENABLED(USE_WATCHDOG)
+  #include "watchdog.h"
+#endif
 
 //===========================================================================
 //================================== macros =================================
@@ -818,8 +820,11 @@ static void updateTemperaturesFromRawValues() {
   #if HAS_FILAMENT_SENSOR
     filament_width_meas = analog2widthFil();
   #endif
-  //Reset the watchdog after we know we have a temperature measurement.
-  watchdog_reset();
+
+  #if ENABLED(USE_WATCHDOG)
+    // Reset the watchdog after we know we have a temperature measurement.
+    watchdog_reset();
+  #endif
 
   CRITICAL_SECTION_START;
   temp_meas_ready = false;

--- a/watchdog.cpp
+++ b/watchdog.cpp
@@ -1,25 +1,14 @@
 #include "Marlin.h"
 
 #if ENABLED(USE_WATCHDOG)
-#include <avr/wdt.h>
 
 #include "watchdog.h"
-#include "ultralcd.h"
 
-//===========================================================================
-//============================ private variables ============================
-//===========================================================================
-
-//===========================================================================
-//================================ functions ================================
-//===========================================================================
-
-
-/// intialise watch dog with a 4 sec interrupt time
+// Initialize watchdog with a 4 sec interrupt time
 void watchdog_init() {
   #if ENABLED(WATCHDOG_RESET_MANUAL)
-    //We enable the watchdog timer, but only for the interrupt.
-    //Take care, as this requires the correct order of operation, with interrupts disabled. See the datasheet of any AVR chip for details.
+    // We enable the watchdog timer, but only for the interrupt.
+    // Take care, as this requires the correct order of operation, with interrupts disabled. See the datasheet of any AVR chip for details.
     wdt_reset();
     _WD_CONTROL_REG = _BV(_WD_CHANGE_BIT) | _BV(WDE);
     _WD_CONTROL_REG = _BV(WDIE) | WDTO_4S;
@@ -28,23 +17,18 @@ void watchdog_init() {
   #endif
 }
 
-/// reset watchdog. MUST be called every 1s after init or avr will reset.
-void watchdog_reset() {
-  wdt_reset();
-}
-
 //===========================================================================
 //=================================== ISR ===================================
 //===========================================================================
 
-//Watchdog timer interrupt, called if main program blocks >1sec and manual reset is enabled.
+// Watchdog timer interrupt, called if main program blocks >1sec and manual reset is enabled.
 #if ENABLED(WATCHDOG_RESET_MANUAL)
-ISR(WDT_vect) {
-  SERIAL_ERROR_START;
-  SERIAL_ERRORLNPGM("Something is wrong, please turn off the printer.");
-  kill(PSTR("ERR:Please Reset")); //kill blocks //16 characters so it fits on a 16x2 display
-  while (1); //wait for user or serial reset
-}
-#endif//RESET_MANUAL
+  ISR(WDT_vect) {
+    SERIAL_ERROR_START;
+    SERIAL_ERRORLNPGM("Something is wrong, please turn off the printer.");
+    kill(PSTR("ERR:Please Reset")); //kill blocks //16 characters so it fits on a 16x2 display
+    while (1); //wait for user or serial reset
+  }
+#endif //WATCHDOG_RESET_MANUAL
 
-#endif//USE_WATCHDOG
+#endif //USE_WATCHDOG

--- a/watchdog.h
+++ b/watchdog.h
@@ -2,16 +2,13 @@
 #define WATCHDOG_H
 
 #include "Marlin.h"
+#include <avr/wdt.h>
 
-#if ENABLED(USE_WATCHDOG)
-  // initialize watch dog with a 1 sec interrupt time
-  void watchdog_init();
-  // pad the dog/reset watchdog. MUST be called at least every second after the first watchdog_init or AVR will go into emergency procedures..
-  void watchdog_reset();
-#else
-  //If we do not have a watchdog, then we can have empty functions which are optimized away.
-  FORCE_INLINE void watchdog_init() {};
-  FORCE_INLINE void watchdog_reset() {};
-#endif
+// Initialize watchdog with a 4 second interrupt time
+void watchdog_init();
+
+// Reset watchdog. MUST be called at least every 4 seconds after the
+// first watchdog_init or AVR will go into emergency procedures.
+inline void watchdog_reset() { wdt_reset(); }
 
 #endif


### PR DESCRIPTION
Addressing suggestion #195
- Move reset_watchdog to an inline in the header
- Remove extra code to define null functions when `USE_WATCHDOG` is disabled
- Make watchdog code conditional as-usual in `temperature.cpp`
- Watchdog doesn't need `ultralcd.h` AFAICT