### PR TITLE
Fixed missing #if in MiniKossel Customization.h file

### DIFF
--- a/configurations/vendor/generic/MiniKossel/Customization.h
+++ b/configurations/vendor/generic/MiniKossel/Customization.h
@@ -17,13 +17,10 @@
 #define PID_MAX BANG_MAX // limits current to nozzle while PID is active (see PID_FUNCTIONAL_RANGE below); 255=full current
 #define PID_FUNCTIONAL_RANGE 10 // If the temperature difference between the target temperature and the actual temperature
 
-#if ENABLED(PIDTEMP)
 // Ultimaker
 #define  DEFAULT_Kp 22.2
 #define  DEFAULT_Ki 1.08
 #define  DEFAULT_Kd 114
-
-#endif // PIDTEMP
 
 #define DELTA_SEGMENTS_PER_SECOND 200
 

--- a/configurations/vendor/generic/MiniKossel/Customization.h
+++ b/configurations/vendor/generic/MiniKossel/Customization.h
@@ -17,6 +17,7 @@
 #define PID_MAX BANG_MAX // limits current to nozzle while PID is active (see PID_FUNCTIONAL_RANGE below); 255=full current
 #define PID_FUNCTIONAL_RANGE 10 // If the temperature difference between the target temperature and the actual temperature
 
+#if ENABLED(PIDTEMP)
 // Ultimaker
 #define  DEFAULT_Kp 22.2
 #define  DEFAULT_Ki 1.08


### PR DESCRIPTION
Missing #if ENABLED(PIDTEMP) in MiniKossel customizatio.h file 

https://github.com/MarlinFirmware/MarlinDev/blob/master/configurations/vendor/generic/MiniKossel/Customization.h#L25

I do not have this kind of board, but from my understanding that code block either should be under PIDTEMP condition, or the #endif should be removed. I chose the first one, but I can update the PR if the other one is needed. 
