### PR TITLE
Dutch translations

### DIFF
--- a/language_nl.h
+++ b/language_nl.h
@@ -121,8 +121,8 @@
 #define MSG_BABYSTEP_Y                      "Babystap Y"
 #define MSG_BABYSTEP_Z                      "Babystap Z"
 #define MSG_ENDSTOP_ABORT                   "Endstop afbr."
-#define MSG_END_HOUR                        "hours"
-#define MSG_END_MINUTE                      "minutes"
+#define MSG_END_HOUR                        "uur"
+#define MSG_END_MINUTE                      "minuten"
 
 #if ENABLED(DELTA_CALIBRATION_MENU)
   #define MSG_DELTA_CALIBRATE               "Delta Calibratie"


### PR DESCRIPTION
Note that "uur" is not plural, but this is correct in terms of time remaining. For example: "10 uur en 50 minuten".