### PR TITLE
Use next open E connector for Y2/Z2

### DIFF
--- a/Conditionals.h
+++ b/Conditionals.h
@@ -469,6 +469,7 @@
   #define HAS_E1_ENABLE (PIN_EXISTS(E1_ENABLE))
   #define HAS_E2_ENABLE (PIN_EXISTS(E2_ENABLE))
   #define HAS_E3_ENABLE (PIN_EXISTS(E3_ENABLE))
+  #define HAS_E4_ENABLE (PIN_EXISTS(E4_ENABLE))
   #define HAS_X_DIR (PIN_EXISTS(X_DIR))
   #define HAS_X2_DIR (PIN_EXISTS(X2_DIR))
   #define HAS_Y_DIR (PIN_EXISTS(Y_DIR))
@@ -479,6 +480,7 @@
   #define HAS_E1_DIR (PIN_EXISTS(E1_DIR))
   #define HAS_E2_DIR (PIN_EXISTS(E2_DIR))
   #define HAS_E3_DIR (PIN_EXISTS(E3_DIR))
+  #define HAS_E4_DIR (PIN_EXISTS(E4_DIR))
   #define HAS_X_STEP (PIN_EXISTS(X_STEP))
   #define HAS_X2_STEP (PIN_EXISTS(X2_STEP))
   #define HAS_Y_STEP (PIN_EXISTS(Y_STEP))
@@ -489,6 +491,7 @@
   #define HAS_E1_STEP (PIN_EXISTS(E1_STEP))
   #define HAS_E2_STEP (PIN_EXISTS(E2_STEP))
   #define HAS_E3_STEP (PIN_EXISTS(E3_STEP))
+  #define HAS_E4_STEP (PIN_EXISTS(E4_STEP))
 
   /**
    * Helper Macros for heaters and extruder fan

--- a/pins/pins.h
+++ b/pins/pins.h
@@ -262,16 +262,26 @@
   #define Z_MIN_PIN          -1
 #endif
 
+//
+// Dual Y and Dual Z support
+// These options are mutually-exclusive
+//
+
+#define __EPIN(p,q) E##p##_##q##_PIN
+#define _EPIN(p,q) __EPIN(p,q)
+
+// The Y2 axis, if any, should be the next open extruder port
 #ifndef Y2_STEP_PIN
-  #define Y2_STEP_PIN      E1_STEP_PIN
-  #define Y2_DIR_PIN       E1_DIR_PIN
-  #define Y2_ENABLE_PIN    E1_ENABLE_PIN
+  #define Y2_STEP_PIN   _EPIN(EXTRUDERS, STEP)
+  #define Y2_DIR_PIN    _EPIN(EXTRUDERS, DIR)
+  #define Y2_ENABLE_PIN _EPIN(EXTRUDERS, ENABLE)
 #endif
 
+// The Z2 axis, if any, should be the next open extruder port
 #ifndef Z2_STEP_PIN
-  #define Z2_STEP_PIN      E1_STEP_PIN
-  #define Z2_DIR_PIN       E1_DIR_PIN
-  #define Z2_ENABLE_PIN    E1_ENABLE_PIN
+  #define Z2_STEP_PIN   _EPIN(EXTRUDERS, STEP)
+  #define Z2_DIR_PIN    _EPIN(EXTRUDERS, DIR)
+  #define Z2_ENABLE_PIN _EPIN(EXTRUDERS, ENABLE)
 #endif
 
 #define SENSITIVE_PINS { 0, 1, \


### PR DESCRIPTION
Addressing issue MarlinFirmware/Marlin#1410. The Y2 or Z2 pins should be based on the number of extruders, taking the next available port. Mainly applies to the Azteeg X3 Plus, but helps all multi-extruder boards.