### PR TITLE
Fix Z_RAISE_AFTER_PROBING for non DELTA printers

### DIFF
--- a/Marlin_main.cpp
+++ b/Marlin_main.cpp
@@ -3201,6 +3201,11 @@ inline void gcode_G28() {
       // Sled assembly for Cartesian bots
       #if ENABLED(Z_PROBE_SLED)
         dock_sled(true); // dock the sled
+      #elif Z_RAISE_AFTER_PROBING > 0
+         // Raise Z axis for non-delta and non servo based probes
+         #if !defined(HAS_SERVO_ENDSTOPS) && DISABLED(Z_PROBE_ALLEN_KEY) && DISABLED(Z_PROBE_SLED)
+           raise_z_after_probing();
+         #endif
       #endif
 
     #endif // !DELTA


### PR DESCRIPTION
Z_RAISE_AFTER_PROBING value was being ignored by Marlin because raise_z_after_probing() was only called if the printer type was set to a DELTA or if the printer had a docking sled for the probe.

This patch originates from MarlinFirmware/Marlin#3057