### PR TITLE
Introduce M108 cancel wait for heatup and cooldown of the hotend and bed

### DIFF
--- a/Marlin_main.cpp
+++ b/Marlin_main.cpp
@@ -139,7 +139,7 @@
  * M105 - Read current temp
  * M106 - Fan on
  * M107 - Fan off
- * M108 - Cancel heatup and wait for the hotend and bed, this G-code is asynchronously handled in the get_serial_commands() parser
+ * M108 - Cancel wait for heatup and cooldown of the hotend and bed, this G-code is asynchronously handled in the get_serial_commands() parser
  * M109 - Sxxx Wait for extruder current temp to reach target temp. Waits only when heating
  *        Rxxx Wait for extruder current temp to reach target temp. Waits when heating and cooling
  *        IF AUTOTEMP is enabled, S<mintemp> B<maxtemp> F<factor>. Exit autotemp by any M109 without F
@@ -3916,7 +3916,7 @@ inline void gcode_M105() {
 #endif // HAS_FAN
 
 /**
- * M108: Cancel heatup and wait for the hotend and bed, this G-code is asynchronously handled in the get_serial_commands() parser
+ * M108: Cancel wait for heatup and cooldown of the hotend and bed, this G-code is asynchronously handled in the get_serial_commands() parser
  */
 inline void gcode_M108() {
   cancel_wait_heatup = true;

--- a/ultralcd.cpp
+++ b/ultralcd.cpp
@@ -390,7 +390,7 @@ static void lcd_return_to_status() { lcd_goto_menu(lcd_status_screen); }
     card.sdprinting = false;
     card.closefile();
     autotempShutdown();
-    cancel_heatup = true;
+    cancel_wait_heatup = true;
     lcd_setstatus(MSG_PRINT_ABORTED, true);
   }
 

--- a/ultralcd.h
+++ b/ultralcd.h
@@ -52,7 +52,7 @@
   extern int absPreheatHPBTemp;
   extern int absPreheatFanSpeed;
 
-  extern bool cancel_heatup;
+  extern bool cancel_wait_heatup;
 
   #if ENABLED(FILAMENT_LCD_DISPLAY)
     extern millis_t previous_lcd_status_ms;


### PR DESCRIPTION
This G-code is asynchronously handled in the `get_serial_commands()` parser.

Continued discussion from https://github.com/MarlinFirmware/Marlin/pull/3611.